### PR TITLE
Fixing a bug that prevented arrays from being passed to .mget().

### DIFF
--- a/redis-mock.js
+++ b/redis-mock.js
@@ -948,7 +948,8 @@
     redismock.mget = function (key, callback) {
         var g = gather(this.mget).apply(this, arguments);
         callback = g.callback;
-        return cb(callback)(null, g.list.map(function (k) {
+        var data = (typeof g.list[0] === 'object') ? g.list[0] : g.list;
+        return cb(callback)(null, data.map(function (k) {
             return cache[k] || null;
         }));
     };


### PR DESCRIPTION
`.mget()` currently only allows keys to be passed as individual arguments in its argument list. node_redis allows this behavior as well as passing an array of keys to be retrieved. This PR adds the latter functionality without breaking the original functionality.

@wilkenstein 
