### PR TITLE
Avoid spurious `undefined` entries in zrange/zrevrange

### DIFF
--- a/redis-mock.js
+++ b/redis-mock.js
@@ -76,7 +76,7 @@
             return 0;
         }
         score = this.invset[member];
-        this.set[score][this.indices[member]] = undefined;
+        this.set[score].splice(this.set[score].indexOf(member), 1);
         this.lengths[score] -= 1;
         if (this.lengths[score] === 0) {
             this.set[score] = undefined;

--- a/test/mocha/redismockSortedSetTest.js
+++ b/test/mocha/redismockSortedSetTest.js
@@ -472,6 +472,27 @@
                 done();
             });
         });
+        it('should return the range for incremented values', function (done) {
+            var k = randkey();
+            var v1 = 'v1', v2 = 'v2', v3 = 'v3';
+            redismock.zincrby(k, 1, v1);
+            redismock.zincrby(k, 1, v2);
+            redismock.zincrby(k, 1, v2);
+            redismock.zincrby(k, 1, v3);
+            redismock.zincrby(k, 1, v3);
+            redismock.zincrby(k, 1, v3);
+            expect(redismock.zrange(k, 0, 1)).to.have.lengthOf(2);
+            expect(redismock.zrange(k, 1, 3)).to.have.lengthOf(2);
+            expect(redismock.zrange(k, 4, 5)).to.have.lengthOf(0);
+            redismock.zrange(k, 0, 2, function (err, reply) {
+                expect(err).to.not.exist;
+                expect(reply).to.have.lengthOf(3);
+                expect(reply[0]).to.equal(v1);
+                expect(reply[1]).to.equal(v2);
+                expect(reply[2]).to.equal(v3);
+                done();
+            });
+        });
         it('should return the range for negative numbers', function (done) {
             var k = randkey();
             var v1 = 'v1', v2 = 'v2', v3 = 'v3';


### PR DESCRIPTION
Fix for incorrect `zrange`/`zrevrange` behaviour with sorted sets. Tested with `zincrby` because that was my use case, but anything that called `SortedSet.rem` would be affected.

The array returned by `zrange`/`zrevrange` includes `undefined` entries, which are left over in the `this.set[score]` from previous values that have been removed/incremented.

Note that this PR reverts a change that was introduced intentionally in 61fb83cd9b9c4f6 to improve performance.
