### PR TITLE
fix a crash in zadd when sm[1] is undefined

### DIFF
--- a/redis-mock.js
+++ b/redis-mock.js
@@ -1823,7 +1823,7 @@
                         return elem !== null;
                     })
                     .map(function (sm) {
-                        return cache[zsets][key].add(sm[0], sm[1].toString());
+                        return cache[zsets][key].add(sm[0], sm[1] ? sm[1].toString() : sm[1]);
                     })
                     .reduce(function (cnt, ret) {
                         return cnt + ret;


### PR DESCRIPTION
it was crashing for me when using with kue-scheduler

```
     Uncaught TypeError: Cannot call method 'toString' of undefined
      at node_modules/redis-js/redis-mock.js:1827:67
      at Array.map (native)
      at Object.<anonymous> (node_modules/redis-js/redis-mock.js:1825:22)
      at Object.end (node_modules/redis-js/redis-mock.js:262:38)
      at Object.redismock.zadd (node_modules/redis-js/redis-mock.js:1834:14)
      at Object.redismock.(anonymous function) (node_modules/redis-js/redis-mock.js:3521:33)
      at Object.redismock.(anonymous function) [as zadd] (node_modules/redis-js/redis-mock.js:3534:24)
      at node_modules/redis-js/redis-mock.js:3215:26
      at Array.forEach (native)
      at Object.rc.exec (node_modules/redis-js/redis-mock.js:3214:21)
      at Job.state (node_modules/kue/lib/queue/job.js:694:9)
      at node_modules/kue-scheduler/index.js:454:18
      at Array.forEach (native)
      at Queue.finish (node_modules/kue-scheduler/index.js:446:12)
```
