### PR TITLE
Fix persist, expire time removed by persist command should return ttl -1

### DIFF
--- a/redis-mock.js
+++ b/redis-mock.js
@@ -384,6 +384,7 @@
     redismock.persist = function (key, callback) {
         if (this.exists(key) && timeouts[key]) {
             clearTimeout(timeouts[key].timeout);
+            delete timeouts[key];
             return cb(callback)(null, 1);
         }
         return cb(callback)(null, 0);

--- a/test/mocha/redismockKeysTest.js
+++ b/test/mocha/redismockKeysTest.js
@@ -452,9 +452,11 @@
             setTimeout(function () {
                 expect(redismock.get(k)).to.equal(v);
                 expect(redismock.persist(k)).to.equal(1);
+                expect(redismock.ttl(k)).to.equal(-1);
             }, 750);
             setTimeout(function () {
                 expect(redismock.get(k)).to.equal(v);
+                expect(redismock.ttl(k)).to.equal(-1);
                 done();
             }, 1300);
         });


### PR DESCRIPTION
## Expected behavior

Remove `expire time` from key using `persist` command, then ttl should return -1

Redis doc -> https://redis.io/commands/ttl/

From redis server command

```
expire key 3600

1

ttl key

3600

persist key

1

ttl key

-1
```

## Actual behavior

It doesn't return ttl -1 after run `persist` command.

## Steps to reproduce the behavior

1. Create key with expire time
2. Run `persist` command with `1. key`
3. Run `ttl` command with `1. key`
